### PR TITLE
jx-spring-boot-gradle-quickstart to 0.0.5

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.4
 - name: jx-spring-boot-gradle-quickstart
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.4
+  version: 0.0.5
 - name: spring-petclinic-config-server
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9


### PR DESCRIPTION
Promote jx-spring-boot-gradle-quickstart to version 0.0.5